### PR TITLE
update client exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 /logs/
 /tests/tmp/*
 *tmp*
+.DS_Store

--- a/src/Client.php
+++ b/src/Client.php
@@ -350,7 +350,7 @@ class Client
             $response = $this->getHttpClient()->send($request, $options);
             $this->lastResponse = $response;
         } catch (RequestException $exception) {
-            $exception = new ClientException($request, $exception->getResponse(), $exception->getMessage());
+            $exception = new ClientException($request, $exception->getResponse(), $exception->getMessage(), $exception->getCode());
             throw $exception;
         }
         list($callsMade, $callsLimit) = explode('/', $response->getHeaderLine('http_x_shopify_shop_api_call_limit'));

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -26,7 +26,7 @@ class ClientException extends RuntimeException
      */
     protected $response;
 
-    public function __construct($request, $response, $message = '', $code = 0)
+    public function __construct(RequestInterface $request, ResponseInterface $response = null, $message = '', $code = 0)
     {
         $this->request = $request;
         $this->response = $response;


### PR DESCRIPTION
* Added type hint for `$request` and `$response`
* Made `$response` optional, as in [Guzzle's RequestException](https://github.com/guzzle/guzzle/blob/411b0764b8e24ea872579316e656f9311d6846a0/src/Exception/RequestException.php#L23)
* Added passing exception code, so we can use it:
    ```php
    try {
        $shopManager->get();
    } catch (ClientException $exception) {
        if ($exception->getCode() == 401) {
            // Unauthorized request
        }
    }
    ```