### PR TITLE
new token format

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -22,7 +22,7 @@ class AccessToken
 
     public function __construct($token)
     {
-        if (0 === preg_match('/^([a-zA-Z0-9]{10,100})$/', $token)) {
+        if (0 === preg_match('/^([a-zA-Z0-9_]{10,100})$/', $token)) {
             throw new InvalidArgumentException('Access token should be between 10 and 100 letters and numbers');
         }
         $this->token = $token;


### PR DESCRIPTION
The length of newly generated Shopify access tokens will increase from 32 to 38 characters, adding a static prefix of shpat_ (for public apps), shpca_ (for custom apps), or shppa_ (for legacy private apps). This change will take effect on April 1st, and will impact all access tokens generated after this date.