### PR TITLE
Update AccessToken.php

### DIFF
--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -22,7 +22,7 @@ class AccessToken
 
     public function __construct($token)
     {
-        if (0 === preg_match('/^([a-zA-Z0-9]{10,100})$/', $token)) {
+        if (0 === preg_match('/^([_a-zA-Z0-9]{10,100})$/', $token)) {
             throw new InvalidArgumentException('Access token should be between 10 and 100 letters and numbers');
         }
         $this->token = $token;


### PR DESCRIPTION
Shopify recently changed the format of the access token to something like: shppa_56b57f128d5r9de76jd953aa31a28d51. The underline is causing the Exception to be thrown.